### PR TITLE
use browse-url function instead of browse-url-default-browser

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -845,7 +845,7 @@ ENTRY will vary with regard to the TYPE, if it is a symbol, it will be converted
   "Open the current issue in external browser."
   (interactive)
   (ensure-on-issue
-   (browse-url-default-browser (concat jiralib-url "/browse/" (org-jira-id)))))
+   (browse-url (concat jiralib-url "/browse/" (org-jira-id)))))
 
 ;;;###autoload
 (defun org-jira-get-issues-from-filter (filter)


### PR DESCRIPTION
The proper way to browse an URL from Emacs is to call the `browse-url' function
that will eventually use the browse-url-default-browser.  This is important
because browse-url is in the autoload while browse-url-default-browser is not.
