### PR TITLE
added option for setting a default tag for all issues

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -144,6 +144,9 @@ variables.
 (defvar org-jira-issue-id-history '()
   "Prompt history for issue id.")
 
+(defvar org-jira-global-tag nil
+  "Default tag to add to every issue")
+
 (defmacro ensure-on-issue (&rest body)
   "Make sure we are on an issue heading, before executing BODY."
 
@@ -439,6 +442,14 @@ See`org-jira-get-issue-list'"
                        (point))
                      (replace-regexp-in-string "-" "_" issue-id)
                      nil)
+                    (when org-jira-global-tag
+                      (org-change-tag-in-region
+                       (point-min)
+                       (save-excursion
+                         (forward-line 1)
+                         (point))
+                       org-jira-global-tag
+                       nil))
 
                     (mapc (lambda (entry)
                             (let ((val (org-jira-get-issue-val entry issue)))


### PR DESCRIPTION
I don't know if this is something anybody else would want, but I added the ability to set a default tag to all of the items that org-jira creates.